### PR TITLE
univariate gaussian kernel, add reference_time_col as a grouping variable for model output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dynamic = ["version"]
 dependencies = [
     "numpy",
     "polars",
-    "scikit-learn"
+    "scikit-learn",
+    "scipy"
 ]
 
 [project.optional-dependencies]

--- a/src/postpredict/weighters.py
+++ b/src/postpredict/weighters.py
@@ -1,4 +1,12 @@
+import collections
+
 import numpy as np
+
+
+class Parameter(collections.UserDict):
+    def __init__(self, value: np.ndarray, trainable: bool = True):
+        self.value = value
+        self.trainable = trainable
 
 
 class EqualWeighter():
@@ -16,14 +24,48 @@ class EqualWeighter():
             Training set features used for weighting. There is one row for each
             training set instance and one column for each of the p features.
         test_X: dataframe or array of shape (n_test, p)
-            Test set features used for weighting. There is one row and one
-            column for each of the p features.
+            Test set features used for weighting. There is one row for each test
+            set instance and one column for each of the p features.
         
         Returns
         -------
-        numpy array of length n_train with weights for each training set
-        instance, where weights sum to 1.
+        numpy array of shape (n_test, n_train) with weights for each training set
+        instance, where weights sum to 1 within each row.
         """
         n_train = train_X.shape[0]
         n_test = test_X.shape[0]
         return np.full((n_test, n_train), 1 / n_train)
+
+
+class UnivariateGaussianKernel():
+    def __init__(self, h):
+        self.parameters = {
+            'h': Parameter(
+                    value = h,
+                    trainable = True
+                )
+        }
+    
+    
+    def get_weights(self, train_X, test_X):
+        """
+        Compute training set observation weights.
+        
+        Parameters
+        ----------
+        train_X: dataframe or array of shape (n_train, 1)
+            Training set features used for weighting. There is one row for each
+            training set instance and one column for a single feature.
+        test_X: dataframe or array of shape (n_test, 1)
+            Test set features used for weighting. There is one row for each
+            test set instance and one column for a single feature.
+        
+        Returns
+        -------
+        numpy array of shape (n_test, n_train) with weights for each training set
+        instance, where weights sum to 1 within each row.
+        """
+        n_train = train_X.shape[0]
+        n_test = test_X.shape[0]
+        prop_weights = np.exp(-0.5 / self.parameters['h'].value * (test_X - train_X.reshape(1, n_train))**2)
+        return prop_weights / np.sum(prop_weights, axis = 1, keepdims = True)

--- a/src/postpredict/weighters.py
+++ b/src/postpredict/weighters.py
@@ -40,7 +40,7 @@ class EqualWeighter():
 class UnivariateGaussianKernel():
     def __init__(self, h):
         self.parameters = {
-            'h': Parameter(
+            "h": Parameter(
                     value = h,
                     trainable = True
                 )
@@ -66,6 +66,5 @@ class UnivariateGaussianKernel():
         instance, where weights sum to 1 within each row.
         """
         n_train = train_X.shape[0]
-        n_test = test_X.shape[0]
-        prop_weights = np.exp(-0.5 / self.parameters['h'].value * (test_X - train_X.reshape(1, n_train))**2)
+        prop_weights = np.exp(-0.5 / self.parameters["h"].value * (test_X - train_X.reshape(1, n_train))**2)
         return prop_weights / np.sum(prop_weights, axis = 1, keepdims = True)

--- a/tests/postpredict/dependence/conftest.py
+++ b/tests/postpredict/dependence/conftest.py
@@ -23,7 +23,8 @@ import pytest
 
 @pytest.fixture
 def wide_model_out():
-    wmo_group1 = pl.DataFrame({
+    wmo_group1_time1 = pl.DataFrame({
+        "reference_date": [datetime.strptime("2020-01-15", "%Y-%m-%d")] * 10,
         "location": ["a"] * 10,
         "population": [100.0] * 10,
         "age_group": ["young"] * 10,
@@ -33,23 +34,23 @@ def wide_model_out():
         "horizon2": [9.3, 6.3, 7.9, 7.5, 13.5, 11.8, 8.6, 17.7, 7.2, 12.2],
         "horizon3": [17.6, 15.6, 13.5, 14.2, 18.3, 15.9, 14.5, 23.9, 12.4, 16.3]
     })
-    return pl.concat([
-        wmo_group1,
-        wmo_group1.with_columns(
+    wmo_all_groups_time1 = pl.concat([
+        wmo_group1_time1,
+        wmo_group1_time1.with_columns(
             age_group = pl.lit("old"),
             horizon1 = pl.col("horizon1") + 4.0,
             horizon2 = pl.col("horizon2") + 4.0,
             horizon3 = pl.col("horizon3") + 4.0,
             population = 150.0
         ),
-        wmo_group1.with_columns(
+        wmo_group1_time1.with_columns(
             location = pl.lit("b"),
             horizon1 = pl.col("horizon1") + 12.0,
             horizon2 = pl.col("horizon2") + 12.0,
             horizon3 = pl.col("horizon3") + 12.0,
             population = 200.0
         ),
-        wmo_group1.with_columns(
+        wmo_group1_time1.with_columns(
             location = pl.lit("b"),
             age_group = pl.lit("old"),
             horizon1 = pl.col("horizon1") - 2.0,
@@ -58,6 +59,16 @@ def wide_model_out():
             population = 250.0
         )
     ])
+    wmo = pl.concat([
+        wmo_all_groups_time1,
+        wmo_all_groups_time1.with_columns(
+            reference_date = pl.lit(datetime.strptime("2020-01-22", "%Y-%m-%d")),
+            horizon1 = pl.col("horizon1") + 42.0,
+            horizon2 = pl.col("horizon2") + 42.0,
+            horizon3 = pl.col("horizon3") + 42.0
+        )
+    ])
+    return wmo
 
 @pytest.fixture
 def long_model_out(wide_model_out):
@@ -65,7 +76,7 @@ def long_model_out(wide_model_out):
         wide_model_out
         .unpivot(
             ["horizon1", "horizon2", "horizon3"],
-            index=["location", "population", "age_group", "output_type", "output_type_id"],
+            index=["reference_date", "location", "population", "age_group", "output_type", "output_type_id"],
             variable_name="horizon"
         )
         .with_columns(horizon=pl.col("horizon").str.slice(-1, 1).cast(int))
@@ -88,7 +99,8 @@ def templates():
 
 @pytest.fixture
 def wide_expected_final():
-    ef_group1 = pl.DataFrame({
+    ef_group1_time1 = pl.DataFrame({
+        "reference_date": [datetime.strptime("2020-01-15", "%Y-%m-%d")] * 10,
         "location": ["a"] * 10,
         "population": [100.0] * 10,
         "age_group": ["young"] * 10,
@@ -98,9 +110,9 @@ def wide_expected_final():
         "horizon2": [9.3, 7.2, 6.3, 8.6, 13.5, 17.7, 7.9, 7.5, 11.8, 12.2],
         "horizon3": [14.5, 15.6, 12.4, 16.3, 18.3, 23.9, 14.2, 13.5, 15.9, 17.6]
     })
-    return pl.concat([
-        ef_group1,
-        ef_group1.with_columns(
+    ef_all_groups_time1 = pl.concat([
+        ef_group1_time1,
+        ef_group1_time1.with_columns(
             age_group = pl.lit("old"),
             output_type_id = pl.col("output_type_id") + 10,
             horizon1 = pl.col("horizon1") + 4.0,
@@ -108,7 +120,7 @@ def wide_expected_final():
             horizon3 = pl.col("horizon3") + 4.0,
             population = 150.0
         ),
-        ef_group1.with_columns(
+        ef_group1_time1.with_columns(
             location = pl.lit("b"),
             output_type_id = pl.col("output_type_id") + 20,
             horizon1 = pl.col("horizon1") + 12.0,
@@ -116,7 +128,7 @@ def wide_expected_final():
             horizon3 = pl.col("horizon3") + 12.0,
             population = 200.0
         ),
-        ef_group1.with_columns(
+        ef_group1_time1.with_columns(
             location = pl.lit("b"),
             age_group = pl.lit("old"),
             output_type_id = pl.col("output_type_id") + 30,
@@ -126,6 +138,16 @@ def wide_expected_final():
             population = 250.0
         )
     ])
+    ef = pl.concat([
+        ef_all_groups_time1,
+        ef_all_groups_time1.with_columns(
+            reference_date = pl.lit(datetime.strptime("2020-01-22", "%Y-%m-%d")),
+            horizon1 = pl.col("horizon1") + 42.0,
+            horizon2 = pl.col("horizon2") + 42.0,
+            horizon3 = pl.col("horizon3") + 42.0
+        )
+    ])
+    return ef
 
 @pytest.fixture
 def long_expected_final(wide_expected_final):
@@ -133,7 +155,7 @@ def long_expected_final(wide_expected_final):
         wide_expected_final
         .unpivot(
             ["horizon1", "horizon2", "horizon3"],
-            index=["location", "population", "age_group", "output_type", "output_type_id"],
+            index=["reference_date", "location", "population", "age_group", "output_type", "output_type_id"],
             variable_name="horizon"
         )
         .with_columns(horizon=pl.col("horizon").str.slice(-1, 1).cast(int))

--- a/tests/postpredict/dependence/test_apply_shuffle.py
+++ b/tests/postpredict/dependence/test_apply_shuffle.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import polars as pl
+from datetime import datetime
 from polars.testing import assert_frame_equal
 from postpredict.dependence import TimeDependencePostprocessor
 
@@ -15,15 +16,23 @@ def test_apply_shuffle(wide_model_out, templates, wide_expected_final, monkeypat
     tdp = TimeDependencePostprocessor(rng = np.random.default_rng(42))
     
     # To match Fig 2 of Clark et al., we just keep the portion of the data for
-    # location "a", age_group "young"
+    # reference_date 2020-01-15, location "a", age_group "young"
     actual_final = tdp._apply_shuffle(
-        wide_model_out.filter((pl.col("location") == "a") & (pl.col("age_group") == "young")),
+        wide_model_out.filter(
+            (pl.col("reference_date") == datetime.strptime("2020-01-15", "%Y-%m-%d")) &
+            (pl.col("location") == "a") &
+            (pl.col("age_group") == "young")
+        ),
         [f"horizon{h}" for h in range(1, 4)],
         templates
     )
     assert_frame_equal(
         actual_final,
-        wide_expected_final.filter((pl.col("location") == "a") & (pl.col("age_group") == "young"))
+        wide_expected_final.filter(
+            (pl.col("reference_date") == datetime.strptime("2020-01-15", "%Y-%m-%d")) &
+            (pl.col("location") == "a") &
+            (pl.col("age_group") == "young")
+        )
     )
 
 
@@ -40,14 +49,22 @@ def test_apply_shuffle_reproducible_with_ties(wide_model_out, templates, wide_ex
     
     tdp = TimeDependencePostprocessor(rng = np.random.default_rng(42))
     actual_final_1 = tdp._apply_shuffle(
-        wide_model_out.filter((pl.col("location") == "a") & (pl.col("age_group") == "young")),
+        wide_model_out.filter(
+            (pl.col("reference_date") == datetime.strptime("2020-01-15", "%Y-%m-%d")) &
+            (pl.col("location") == "a") &
+            (pl.col("age_group") == "young")
+        ),
         [f"horizon{h}" for h in range(1, 4)],
         templates_with_ties
     )
 
     tdp = TimeDependencePostprocessor(rng = np.random.default_rng(42))
     actual_final_2 = tdp._apply_shuffle(
-        wide_model_out.filter((pl.col("location") == "a") & (pl.col("age_group") == "young")),
+        wide_model_out.filter(
+            (pl.col("reference_date") == datetime.strptime("2020-01-15", "%Y-%m-%d")) &
+            (pl.col("location") == "a") &
+            (pl.col("age_group") == "young")
+        ),
         [f"horizon{h}" for h in range(1, 4)],
         templates_with_ties
     )

--- a/tests/postpredict/dependence/test_apply_shuffle.py
+++ b/tests/postpredict/dependence/test_apply_shuffle.py
@@ -1,8 +1,9 @@
 # Tests for postpredict.dependence.TimeDependencePostprocessor._apply_shuffle
 
+from datetime import datetime
+
 import numpy as np
 import polars as pl
-from datetime import datetime
 from polars.testing import assert_frame_equal
 from postpredict.dependence import TimeDependencePostprocessor
 

--- a/tests/postpredict/dependence/test_pivot_horizon.py
+++ b/tests/postpredict/dependence/test_pivot_horizon.py
@@ -1,11 +1,11 @@
 # Tests for postpredict.dependence.TimeDependencePostprocessor._pivot_horizon
 
+from datetime import datetime
 from itertools import product
 
 import numpy as np
 import polars as pl
 import pytest
-from datetime import datetime
 from postpredict.dependence import TimeDependencePostprocessor
 
 

--- a/tests/postpredict/dependence/test_pivot_horizon.py
+++ b/tests/postpredict/dependence/test_pivot_horizon.py
@@ -5,6 +5,7 @@ from itertools import product
 import numpy as np
 import polars as pl
 import pytest
+from datetime import datetime
 from postpredict.dependence import TimeDependencePostprocessor
 
 
@@ -22,21 +23,34 @@ def test_pivot_horizon_positive_horizon(long_model_out, monkeypatch):
     tdp.feat_cols = ["location", "age_group", "population"]
     wide_model_out = tdp._pivot_horizon(
         model_out=long_model_out,
+        reference_time_col="reference_date",
         horizon_col="horizon",
         idx_col="output_type_id",
         pred_col="value"
     )
     
-    # expected columns: everything in tdp.key_cols + tdp.feat_cols + "output_type" + "output_type_id" + f"postpredict_horizon{h}"
-    expected_cols = set(tdp.key_cols + tdp.feat_cols + ["output_type", "output_type_id"] + [f"postpredict_horizon{h}" for h in range(1, 4)])
+    # expected columns
+    expected_cols = set(tdp.key_cols + tdp.feat_cols +
+                        ["reference_date", "output_type", "output_type_id"] +
+                        [f"postpredict_horizon{h}" for h in range(1, 4)])
     assert set(wide_model_out.columns) == expected_cols
     
     # same values within each horizon/group
-    for location, age_group, h in product(["a", "b"], ["young", "old"], range(1, 4)):
+    group_horizon_iterable = product(
+        [datetime.strptime(d, "%Y-%m-%d") for d in ["2020-01-15", "2020-01-22"]],
+        ["a", "b"],
+        ["young", "old"],
+        range(1, 4)
+    )
+    for reference_date, location, age_group, h in group_horizon_iterable:
         expected_values = (
             long_model_out
-            .filter((pl.col("location") == location) & (pl.col("age_group") == age_group)
-                    & (pl.col("horizon") == h))
+            .filter(
+                (pl.col("reference_date") == reference_date) &
+                (pl.col("location") == location) &
+                (pl.col("age_group") == age_group) &
+                (pl.col("horizon") == h)
+            )
             [:, "value"]
             .to_numpy()
             .flatten()
@@ -44,7 +58,11 @@ def test_pivot_horizon_positive_horizon(long_model_out, monkeypatch):
         )
         actual_values = (
             wide_model_out
-            .filter((pl.col("location") == location) & (pl.col("age_group") == age_group))
+            .filter(
+                (pl.col("reference_date") == reference_date) &
+                (pl.col("location") == location) &
+                (pl.col("age_group") == age_group)
+            )
             [:, f"postpredict_horizon{h}"]
             .to_numpy()
             .flatten()
@@ -74,21 +92,34 @@ def test_pivot_horizon_negative_horizon(long_model_out, monkeypatch):
     tdp.feat_cols = ["location", "age_group", "population"]
     wide_model_out = tdp._pivot_horizon(
         model_out=model_out,
+        reference_time_col="reference_date",
         horizon_col="horizon",
         idx_col="output_type_id",
         pred_col="value"
     )
     
-    # expected columns: everything in tdp.key_cols + tdp.feat_cols + "output_type" + "output_type_id" + f"postpredict_horizon{h}"
-    expected_cols = set(tdp.key_cols + tdp.feat_cols + ["output_type", "output_type_id"] + [f"postpredict_horizon{h}" for h in range(-1, 2)])
+    # expected columns
+    expected_cols = set(tdp.key_cols + tdp.feat_cols +
+                        ["reference_date", "output_type", "output_type_id"] +
+                        [f"postpredict_horizon{h}" for h in range(-1, 2)])
     assert set(wide_model_out.columns) == expected_cols
     
     # same values within each horizon/group
-    for location, age_group, h in product(["a", "b"], ["young", "old"], range(-1, 2)):
+    group_horizon_iterable = product(
+        [datetime.strptime(d, "%Y-%m-%d") for d in ["2020-01-15", "2020-01-22"]],
+        ["a", "b"],
+        ["young", "old"],
+        range(-1, 2)
+    )
+    for reference_date, location, age_group, h in group_horizon_iterable:
         expected_values = (
             model_out
-            .filter((pl.col("location") == location) & (pl.col("age_group") == age_group)
-                    & (pl.col("horizon") == h))
+            .filter(
+                (pl.col("reference_date") == reference_date) &
+                (pl.col("location") == location) &
+                (pl.col("age_group") == age_group) &
+                (pl.col("horizon") == h)
+            )
             [:, "value"]
             .to_numpy()
             .flatten()
@@ -96,7 +127,11 @@ def test_pivot_horizon_negative_horizon(long_model_out, monkeypatch):
         )
         actual_values = (
             wide_model_out
-            .filter((pl.col("location") == location) & (pl.col("age_group") == age_group))
+            .filter(
+                (pl.col("reference_date") == reference_date) &
+                (pl.col("location") == location) &
+                (pl.col("age_group") == age_group)
+            )
             [:, f"postpredict_horizon{h}"]
             .to_numpy()
             .flatten()
@@ -130,21 +165,34 @@ def test_pivot_horizon_diff_sample_count_by_group(long_model_out, monkeypatch):
     tdp.feat_cols = ["location", "age_group", "population"]
     wide_model_out = tdp._pivot_horizon(
         model_out=model_out,
+        reference_time_col="reference_date",
         horizon_col="horizon",
         idx_col="output_type_id",
         pred_col="value"
     )
     
-    # expected columns: everything in tdp.key_cols + tdp.feat_cols + "output_type" + "output_type_id" + f"postpredict_horizon{h}"
-    expected_cols = set(tdp.key_cols + tdp.feat_cols + ["output_type", "output_type_id"] + [f"postpredict_horizon{h}" for h in range(1, 4)])
+    # expected columns
+    expected_cols = set(tdp.key_cols + tdp.feat_cols +
+                        ["reference_date", "output_type", "output_type_id"] +
+                        [f"postpredict_horizon{h}" for h in range(1, 4)])
     assert set(wide_model_out.columns) == expected_cols
     
     # same values within each horizon/group
-    for location, age_group, h in product(["a", "b"], ["young", "old"], range(1, 4)):
+    group_horizon_iterable = product(
+        [datetime.strptime(d, "%Y-%m-%d") for d in ["2020-01-15", "2020-01-22"]],
+        ["a", "b"],
+        ["young", "old"],
+        range(1, 4)
+    )
+    for reference_date, location, age_group, h in group_horizon_iterable:
         expected_values = (
             model_out
-            .filter((pl.col("location") == location) & (pl.col("age_group") == age_group)
-                    & (pl.col("horizon") == h))
+            .filter(
+                (pl.col("reference_date") == reference_date) &
+                (pl.col("location") == location) &
+                (pl.col("age_group") == age_group) &
+                (pl.col("horizon") == h)
+            )
             [:, "value"]
             .to_numpy()
             .flatten()
@@ -152,7 +200,11 @@ def test_pivot_horizon_diff_sample_count_by_group(long_model_out, monkeypatch):
         )
         actual_values = (
             wide_model_out
-            .filter((pl.col("location") == location) & (pl.col("age_group") == age_group))
+            .filter(
+                (pl.col("reference_date") == reference_date) &
+                (pl.col("location") == location) &
+                (pl.col("age_group") == age_group)
+            )
             [:, f"postpredict_horizon{h}"]
             .to_numpy()
             .flatten()
@@ -188,6 +240,7 @@ def test_pivot_horizon_diff_sample_count_by_horizon_same_group_errors(long_model
     with pytest.raises(ValueError):
         tdp._pivot_horizon(
             model_out=model_out,
+            reference_time_col="reference_date",
             horizon_col="horizon",
             idx_col="output_type_id",
             pred_col="value"
@@ -203,7 +256,9 @@ def test_pivot_horizon_missing_horizon_errors(long_model_out, monkeypatch):
     tdp = TimeDependencePostprocessor(rng = np.random.default_rng(42))
     
     model_out = long_model_out.filter(
-        ~((pl.col("location") == "a") & (pl.col("age_group") == "young") & (pl.col("horizon") == 2))
+        ~((pl.col("reference_date") == datetime.strptime("2020-01-15", "%Y-%m-%d")) &
+          (pl.col("location") == "a") & (pl.col("age_group") == "young") &
+          (pl.col("horizon") == 2))
     )
     
     tdp.key_cols = ["location", "age_group"]
@@ -213,6 +268,7 @@ def test_pivot_horizon_missing_horizon_errors(long_model_out, monkeypatch):
     with pytest.raises(ValueError):
         tdp._pivot_horizon(
             model_out=model_out,
+            reference_time_col="reference_date",
             horizon_col="horizon",
             idx_col="output_type_id",
             pred_col="value"

--- a/tests/postpredict/metrics/test_energy_score.py
+++ b/tests/postpredict/metrics/test_energy_score.py
@@ -65,20 +65,20 @@ def test_energy_score():
         "energy_score": [5.8560677725938221627, 5.9574451598773787708]
     })
     
-    actual_scores_df = energy_score(model_out_wide = model_out_wide,
-                                    obs_data_wide = obs_data_wide,
-                                    key_cols = ["location", "date"],
-                                    pred_cols = ["horizon1", "horizon2", "horizon3"],
-                                    obs_cols = ["value_lead1", "value_lead2", "value_lead3"],
-                                    reduce_mean = False)
+    actual_scores_df = energy_score(model_out_wide=model_out_wide,
+                                    obs_data_wide=obs_data_wide,
+                                    key_cols=["location", "date"],
+                                    pred_cols=["horizon1", "horizon2", "horizon3"],
+                                    obs_cols=["value_lead1", "value_lead2", "value_lead3"],
+                                    reduce_mean=False)
     
-    assert_frame_equal(actual_scores_df, expected_scores_df, atol = 1e-19)
+    assert_frame_equal(actual_scores_df, expected_scores_df, check_row_order=False, atol=1e-19)
     
     expected_mean_score = np.mean([5.8560677725938221627, 5.9574451598773787708])
-    actual_mean_score = energy_score(model_out_wide = model_out_wide,
-                                    obs_data_wide = obs_data_wide,
-                                    key_cols = ["location", "date"],
-                                    pred_cols = ["horizon1", "horizon2", "horizon3"],
-                                    obs_cols = ["value_lead1", "value_lead2", "value_lead3"],
-                                    reduce_mean = True)
+    actual_mean_score = energy_score(model_out_wide=model_out_wide,
+                                     obs_data_wide=obs_data_wide,
+                                     key_cols=["location", "date"],
+                                     pred_cols=["horizon1", "horizon2", "horizon3"],
+                                     obs_cols=["value_lead1", "value_lead2", "value_lead3"],
+                                     reduce_mean=True)
     assert actual_mean_score == pytest.approx(expected_mean_score)

--- a/tests/postpredict/weighters/test_UnivariateGaussianKernel.py
+++ b/tests/postpredict/weighters/test_UnivariateGaussianKernel.py
@@ -1,0 +1,25 @@
+# Tests for postpredict.metrics.energy_score
+
+import numpy as np
+import pytest
+from postpredict.weighters import UnivariateGaussianKernel
+from scipy.stats import norm
+
+
+def test_UnivariateGaussianKernel():
+    test_X = np.arange(-3, 4)[:, np.newaxis]
+    train_X = np.arange(-10, 11)[:, np.newaxis]
+    
+    def get_one_weights_row(test_x, train_X):
+        w = norm.pdf(train_X, loc=test_x, scale=np.sqrt(2.4))
+        return (w / np.sum(w)).reshape(1, train_X.shape[0])
+    
+    expected_weights = np.concat(
+        [get_one_weights_row(test_x, train_X) for test_x in test_X],
+        axis = 0
+    )
+    
+    weighter = UnivariateGaussianKernel(h = 2.4)
+    actual_weights = weighter.get_weights(train_X, test_X)
+    
+    assert actual_weights == pytest.approx(expected_weights)


### PR DESCRIPTION
Two main things, conceptually distinct from each other, are happening in this PR:

1. Add a univariate Gaussian kernel.  See src/postpredict/weighters.py and  
tests/postpredict/weighters/test_UnivariateGaussianKernel.py
    - One question I have here is what the right way to set up data structure for the very simple class `Parameter` is.  Here I extended. `collections.UserDict`.  Is that reasonable?
2. Fix an earlier conceptual error.  For pivoting model output wider, I need to index/group on both the `key_cols` (which identify an observational unit in the sense of panel data) and also the `reference_time_col` (which identifies the time relative to which prediction horizons are defined).  See basically everything else in here other than tests/postpredict/metrics/test_energy_score.py

Additionally, there is a minor change to tests/postpredict/metrics/test_energy_score.py: don't assert equality of up to row order. energy_score uses a `.group_by().map_groups()` construction which doesn't seem to guarantee row order.  We just got lucky that these tests passed before.
